### PR TITLE
A little insight from a yt-dlp user

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -64,14 +64,14 @@ class DownloadQueueWorker(QRunnable):
             "socket_timeout": 10
         }
         if self.task.audio_only:
-            ydl_opts_download["format"] = "bestaudio/best"
-            ydl_opts_download["postprocessors"] = [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3", "preferredquality": "192"}]
+            ydl_opts_download["final_ext"] = "mp3"
+            ydl_opts_download["format"] = "ba/b"
+            ydl_opts_download["postprocessors"] = [{"key": "FFmpegExtractAudio", "nopostoverwrites": False, "preferredcodec": "mp3", "preferredquality": "0"}]
         else:
             if self.task.output_format.lower() == "mp4":
-                ydl_opts_download["format"] = "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio/best"
-                ydl_opts_download["merge_output_format"] = "mp4"
+                ydl_opts_download["format_sort"] = "ext"
             else:
-                ydl_opts_download["format"] = "bestvideo+bestaudio/best"
+                ydl_opts_download["format"] = "bv*+ba/b"
                 ydl_opts_download["merge_output_format"] = self.task.output_format
         if self.task.subtitles:
             ydl_opts_download["writesubtitles"] = True

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -747,9 +747,9 @@ class MainWindow(QMainWindow):
         if not link:
             QMessageBox.warning(self, "Error", "No URL given.")
             return
-        if not (link.startswith("http://") or link.startswith("https://")):
-            QMessageBox.warning(self, "Input Error", "Invalid URL format.")
-            return
+        # if not (link.startswith("http://") or link.startswith("https://")):
+        #     QMessageBox.warning(self, "Input Error", "Invalid URL format.")
+        #     return
         task = DownloadTask(link, self.user_profile.get_default_resolution(), self.user_profile.get_download_path(), self.user_profile.get_proxy(), audio_only=audio, playlist=playlist, from_queue=False)
         add_history_entry(self.history_table, "Fetching...", "Fetching...", link, "Queued", self.user_profile.is_history_enabled())
         self.run_task(task, None)


### PR DESCRIPTION
- Support other than URL
  yt-dlp also supports other than URL, just a video ID for example.
- Optimize `ydl_opts_download`
  cf: [`cli_to_api.py`](https://github.com/yt-dlp/yt-dlp/blob/master/devscripts/cli_to_api.py)
  - mp4: `-S ext`
    (should be `-S vcodec:h264,res,acodec:aac` if u prefer h.264, but pending because your current behavior isn't that.)
  - mp3: `-x --audio-format=mp3 --audio-quality=0`
