### PR TITLE
Improve audio quality (extend audible range)

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -142,7 +142,7 @@ class DownloadQueueWorker(QRunnable):
             if self.task.audio_only:
                 download_options.update({
                     "final_ext": "mp3",
-                    "format": "ba[ext=m4a]/ba/b",
+                    "format": "ba[acodec^=mp3]/ba/b",
                     "postprocessors": [{
                         "key": "FFmpegExtractAudio",
                         "nopostoverwrites": False,


### PR DESCRIPTION
## Description
YouTube puts a LPF of 16kHz on m4a, and 20kHz on opus, so we can hear higher tones with opus
so without `acodec=m4a` is preferred, i think

## Related Issues
(Empty)

## Checklist
- [x] Tested on Windows
- [x] Tested on Linux
- [x] No breaking changes introduced
- [x] Documentation updated if necessary
