### PR TITLE
Fix critical shared memory cleanup bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,10 +26,14 @@ def set_platform_specific_settings():
             print(f"Failed to set Windows-specific settings: {e}")
 
 def cleanup_shared_memory(shared_mem):
-    if shared_mem and shared_mem.isAttached():
-        shared_mem.detach()
-    if shared_mem and shared_mem.isAttached():
-        shared_mem.forceDetach()
+    if shared_mem:
+        try:
+            if shared_mem.isAttached():
+                if not shared_mem.detach():
+                    # Only force detach if normal detach fails
+                    shared_mem.forceDetach()
+        except Exception as e:
+            print(f"Error during shared memory cleanup: {e}")
 
 def create_shared_memory():
     if sys.platform.startswith("win"):


### PR DESCRIPTION
- Fix logic error in cleanup_shared_memory() function
- forceDetach() was never called due to incorrect condition checking
- Add proper exception handling for shared memory operations
- Improve cleanup reliability on application shutdown

The previous implementation had a logical flaw where the second condition would never be true after the first detach() call, making forceDetach() unreachable. This fix ensures proper fallback cleanup mechanism.

## Description
<!-- Briefly describe the changes introduced by this pull request -->

## Related Issues
<!-- List any relevant issues this PR closes -->
Closes #

## Testing Checklist
- [ ] Tested on Windows
- [ ] All tests pass
- [ ] Documentation updated (if needed)
- [ ] Code follows project style guidelines

